### PR TITLE
[Issue11] Fixing Lit-Graph Dependency Reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --remote-only --build-secret GH_LOGIN_PASSW=${{ secrets.GH_LOGIN_PASSW }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --build-secret GH_LOGIN_PASSW=${{ secrets.GH_LOGIN_PASSW }}
+      - run: flyctl deploy --remote-only --build-secret NPM_RC=${{ secrets.NPM_RC }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@laughing-man-studios:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@laughing-man-studios:registry=https://npm.pkg.github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,15 @@ FROM base as build
 
 # Install packages needed to build node modules
 RUN apt-get update -qq && \
-    apt-get install -y python-is-python3 pkg-config build-essential 
+    apt-get install -y python-is-python3 pkg-config build-essential
+
+# Mount GitHub Password Secret
+RUN --mount=type=secret,id=GH_LOGIN_PASSW \
+    GH_LOGIN_PASSW="$(cat /run/secrets/GH_LOGIN_PASSW)"
+
+# Login to GitHub Packages registry
+
+
 
 # Install node modules
 COPY --link package.json package-lock.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,26 +20,20 @@ FROM base as build
 RUN apt-get update -qq && \
     apt-get install -y python-is-python3 pkg-config build-essential
 
-# Mount GitHub Password Secret
-RUN --mount=type=secret,id=GH_LOGIN_PASSW \
-    GH_LOGIN_PASSW="$(cat /run/secrets/GH_LOGIN_PASSW)"
-
-# Login to GitHub Packages registry
-
-
+# Mount .npmrc file with Auth Key
+RUN --mount=type=secret,id=NPM_RC \
+   cat /run/secrets/NPM_RC > .npmrc
 
 # Install node modules
 COPY --link package.json package-lock.json .
-RUN npm install
 RUN npm install -g npm@9.6.6
+RUN npm install
 
 # Copy application code
 COPY --link . .
 
 # Build application
 RUN npm run build
-
-
 
 # Final stage for app image
 FROM base

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,35 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@laughing-man-studios/lit-graph": "2.0.1",
         "@types/express": "^4.17.17",
         "express": "^4.18.2",
-        "lit-graph": "../../Browser/lit-graph/dist",
         "rollup": "^3.21.5"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.2"
       }
     },
-    "../../Browser/lit-graph/dist": {
-      "name": "@laughing-man-studios/lit-graph",
-      "version": "0.0.1",
+    "node_modules/@laughing-man-studios/lit-graph": {
+      "version": "2.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@laughing-man-studios/lit-graph/2.0.1/8cf5c3b5b6b26f26f931e0caac4c7c7d42fdf4cb",
+      "integrity": "sha512-2XedSjyHor+aPhIE2rYUMlTpqlB1KhQd3hCz8R2vUb4NmRtybHD+8XlQ7Pd3JB7LLVEszg5KC3teqz2D+L8U1w==",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.2.4"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
+      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -161,6 +175,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -543,9 +562,33 @@
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
     },
-    "node_modules/lit-graph": {
-      "resolved": "../../Browser/lit-graph/dist",
-      "link": true
+    "node_modules/lit": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.5.tgz",
+      "integrity": "sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.2.tgz",
+      "integrity": "sha512-xXAeVWKGr4/njq0rGC9dethMnYCq5hpKYrgQZYTzawt9YQhMiXfD+T1RgrdY3NamOxwq2aXlb0vOI6e29CKgVQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.7.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.4.tgz",
+      "integrity": "sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@types/express": "^4.17.17",
     "express": "^4.18.2",
-    "lit-graph": "../../Browser/lit-graph/dist",
+    "@laughing-man-studios/lit-graph": "2.0.1",
     "rollup": "^3.21.5"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default [{
     plugins: [nodeResolve()]
 },
 {
-    input: 'node_modules/lit-graph/lit-graph.js',
+    input: 'node_modules/@laughing-man-studios/lit-graph/lit-graph.js',
     output: {
         file: 'dist/lit-graph.min.js',
     },


### PR DESCRIPTION
I was using my local copy of lit-graph to develop and test the CDN locally, but this was blowing up the deploys because npm couldn't find the lit-graph folder in the docker filesystem. This PR changes the lit-graph reference to the GitHub Packages registry instead.

## Proposed Changes

- point lit-graph at GitHub Packages registry
- update package.json
- use correct file path for rollup

Fixes #11